### PR TITLE
dp/product & gp/product

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ as [Gephi](https://gephi.org).
 There are other command-line parameters too:
 
 ```
-python scrape.py --input seeds.txt --depth 1 --prefix /results/
+python scrape.py --input seeds.txt --depth 1 --prefix seeds-txt-depth-1
 ```
 
 Try `python scrape.py --help` for a full list. Be very careful with the 

--- a/carousels.js
+++ b/carousels.js
@@ -42,7 +42,7 @@
         own_img = own_img ? own_img.getAttribute('src') : null;
 
         let item_metadata = {
-            asin: document.location.href.split('/dp/')[1].split('/')[0],
+            asin: document.location.href.split(/(d|g)p/)[1].split('/')[0],
             label: own_title.innerText,
             author: null,
             rank: 0,


### PR DESCRIPTION
Thanks for a very useful tool I can see how this would be quite a useful utility for
tracing black boxed recommendation algorithms.

This commit includes two updates. The first is to allow for `dp/product`
and `gp/product` Amazon URLs. I happened to just bring up a recent Amazon
product in my browser history and it had a `gp/product` in it instead of a 
`dp/product`:

    https://www.amazon.com/gp/product/0307336794

vs

    https://www.amazon.com/dp/product/0307336794

They both seem to resolve to the same page, and generate the same network
so I adjusted scrape.py and carousel.js to allow for either form.

The first time I ran the program I got a file not found error because
scrape.py was trying to write to a non-existent results/ directory.
I like the --prefix option for recording the provenance of where
the data came from (linked to the seed file. So I made some adjustments
to make that a bit clearer, and also to create the directory if
instructed to write somewhere that doesn't exist yet.